### PR TITLE
Nocache

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -213,13 +213,8 @@
          * tiles based on values in valid_tile_keys from inventoryVisibleTile().
          */
         adjustVisibleLevel: function(level, zoom, valid_tile_keys) {
-            // for tracking time of tile usage:
-            var now = new Date().getTime();
-
-            if (!level) {
-                // no tiles for this level yet
-                return;
-            }
+            // no tiles for this level yet
+            if (!level) return;
 
             var scale = 1;
             var theCoord = this.map.coordinate.copy();


### PR DESCRIPTION
This removes the cache from modestmaps. All tests are passing, examples seem fine, and it removes quite a bit of complexity that has been a bit painful (the cause of the 'gah' error) in the past.
