### PR TITLE
Make error messages more helpful

### DIFF
--- a/src/projection.js
+++ b/src/projection.js
@@ -16,11 +16,11 @@
         transformation: null,
 
         rawProject: function(point) {
-            throw "Abstract method not implemented by subclass.";
+            throw "Abstract method rawProject not implemented by subclass.";
         },
 
         rawUnproject: function(point) {
-            throw "Abstract method not implemented by subclass.";
+            throw "Abstract method rawUnproject not implemented by subclass.";
         },
 
         project: function(point) {

--- a/src/provider.js
+++ b/src/provider.js
@@ -22,11 +22,11 @@
         ],
 
         getTileUrl: function(coordinate) {
-            throw "Abstract method not implemented by subclass.";
+            throw "Abstract method getTileUrl not implemented by subclass.";
         },
 
         getTile: function(coordinate) {
-            throw "Abstract method not implemented by subclass.";
+            throw "Abstract method getTile not implemented by subclass.";
         },
 
         // releaseTile is not required


### PR DESCRIPTION
This minor patch makes it less of a mystery which "Abstract method" is "not implemented by subclass", with messages like this: "Abstract method getTileUrl not implemented by subclass".
