### PR TITLE
Fix package.json to stop install warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
   "keywords": ["map", "geo", "browser"],
   "main": "./modestmaps.js",
   "homepage": "https://github.com/stamen/modestmaps-js",
-  "repositories": [{
+  "repository": {
     "type" : "git",
     "url"  : "git://github.com/stamen/modestmaps-js.git"
-  }],
+  },
+  "dependencies": {},
   "devDependencies": {
     "docco": "~0.3.0",
     "uglify-js": "~1.0.0"


### PR DESCRIPTION
When I ran `npm install --dev` I noticed the following warnings.

```
npm WARN package.json modestmaps@1.0.0-beta1 'repositories' (plural) Not supported. Please pick one as the 'repository' field
npm WARN package.json uglify-js@1.0.7 No description
npm WARN package.json docco@0.3.0 No repository field.
```

This change removes the warnings.
